### PR TITLE
ci: restore aws-lc-rs crypto provider, use cargo-c for librustls install

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,7 +91,6 @@ jobs:
       - name: Install cargo-c
         if: matrix.rustls-version == 'main'
         env:
-          # Version picked for MSRV compat.
           LINK: https://github.com/lu-zero/cargo-c/releases/latest/download/
           CARGO_C_FILE: cargo-c-x86_64-unknown-linux-musl.tar.gz
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -96,16 +96,17 @@ jobs:
         run: |
           curl -L $LINK/$CARGO_C_FILE | tar xz -C ~/.cargo/bin
 
-      - name: 'build rustls-ffi (cmake)'
+      - name: 'build rustls-ffi (cargo-c)'
         if: matrix.rustls-version == 'main'
         run: |
           cd $HOME/rustls-ffi
-          cmake \
-            -DCRYPTO_PROVIDER=${{matrix.crypto}} \
-            -DDYN_LINK=on \
-            -DCMAKE_BUILD_TYPE=Release \
-            -S librustls -B build
-          cmake --build build --config "Release"
+          cargo capi install \
+            --libdir lib \
+            --prefix "$HOME/rustls-ffi/build/rust" \
+            --release \
+            --locked \
+            --no-default-features \
+            --features ${{ matrix.crypto }}
 
       - name: 'install test prereqs'
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,7 +52,7 @@ jobs:
         crypto:
           - ring
           # aws-lc-sys v0.21.1 is not building due to compiler warnings
-          # - aws-lc-rs
+          - aws-lc-rs
         rustls-version:
           - v0.14.1
           - main
@@ -86,7 +86,7 @@ jobs:
         if: matrix.rustls-version != 'main'
         run: |
           cd $HOME/rustls-ffi
-          make DESTDIR=$HOME/rustls-ffi/build/rust CRYPTO_PROVIDER=${{ matrix.crypto }} install
+          make CFLAGS="" DESTDIR=$HOME/rustls-ffi/build/rust CRYPTO_PROVIDER=${{ matrix.crypto }} install
 
       - name: Install cargo-c
         if: matrix.rustls-version == 'main'


### PR DESCRIPTION
:wave: @icing As promised here's a quick follow-up to https://github.com/icing/mod_tls/pull/4

The `aws-lc-rs` build issue ended up being specific to the 0.14.1 release. Our old `Makefile` set [`CFLAGS` globally](https://github.com/rustls/rustls-ffi/blob/2014e6154074ba66c0023a683b27fdae93fbeabb/Makefile#L10) with fairly aggressive settings for warnings. The intent was to use those settings when building the `client.c` and `server.c` examples, but it was inadvertently being used by `cargo` when building native dependencies of `librustls`, like `aws-lc-sys`.

That was causing issues because the `aws-lc-sys` version in use doesn't build cleanly w/ that level of pedantic warnings and so was breaking the build. That's been tided up upstream by the AWS folks in `aws-lc`, but for 0.14.1 the easiest thing is to work around this by using `make CFLAGS="" ... install` in our CI.

I also replaced the `cmake` usage with direct `cargo capi` invocation for simplicity/directness.

Thanks again for getting the CI set up! Much appreciated :bow: 