### PR TITLE
tls_cache: fix implicit conversion err on i386/i686

### DIFF
--- a/src/tls_cache.c
+++ b/src/tls_cache.c
@@ -231,6 +231,10 @@ static rustls_result tls_cache_get(
     unsigned int vlen, klen;
     const unsigned char *kdata;
 
+    if (key->len > UINT_MAX || key->len > SSIZE_MAX) {
+        return RUSTLS_RESULT_INVALID_PARAMETER;
+    }
+
     if (!sc->global->session_cache) goto not_found;
     tls_cache_lock(sc->global);
 
@@ -241,7 +245,7 @@ static rustls_result tls_cache_get(
         sc->global->session_cache, cc->server, kdata, klen, buf, &vlen, c->pool);
 
     if (APLOGctrace4(c)) {
-        apr_ssize_t n = klen;
+        apr_ssize_t n = (apr_ssize_t) klen;
         ap_log_cerror(APLOG_MARK, APLOG_TRACE4, rv, c, "retrieve key %d[%8x], found %d val",
             klen, apr_hashfunc_default((const char*)kdata, &n), vlen);
     }


### PR DESCRIPTION
### tls_cache: fix implicit conversion err on i386/i686

Previously on arch's where `apr_ssize_t` is an `int` (e.g. i386) the `tls_cache_get()` function produced an implicit conversion error of the form:

```
error: implicit conversion changes signedness: 'unsigned int' to 'apr_ssize_t' (aka 'int')
```

This commit resolves this error by:

1. Checking the two casts performed by this function are within the range of the types being cast to.
2. Making the cast to `apr_ssize_t` explicit.

### Testing

I wasn't confident in my ability to cross-compile `mod_tls` with autotools so I tested this on a throwaway i686 VM. I confirmed that `main` produced the expected error from #6, and that the patch in this branch resolved the issue.

```
(venv) root@debian-i386:~/mod_tls# uname -a
Linux debian-i386 6.1.0-30-686-pae #1 SMP PREEMPT_DYNAMIC Debian 6.1.124-1 (2025-01-12) i686 GNU/Linux
```

<details>
<summary>pytest -v output:</summary>

```
venv) root@debian-i386:~/mod_tls# pytest -v
================================================================= test session starts ==================================================================
platform linux -- Python 3.11.2, pytest-8.3.4, pluggy-1.5.0 -- /root/venv/bin/python3
cachedir: .pytest_cache
[apache httpd: 2.4.62, mpm: mpm_event, /usr]
rootdir: /root/mod_tls
collected 124 items

test/modules/tls/test_01_apache.py::TestApache::test_tls_01_apache_http PASSED                                                                   [  0%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_args_missing PASSED                                                            [  1%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_single_arg PASSED                                                              [  2%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_file_missing PASSED                                                            [  3%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_file_exist PASSED                                                              [  4%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_listen_missing PASSED                                                          [  4%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_listen_wrong PASSED                                                            [  5%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_listen_valid[443] PASSED                                                       [  6%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_listen_valid[129.168.178.188:443] PASSED                                       [  7%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_listen_valid[[::]:443] PASSED                                                  [  8%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cert_listen_cert PASSED                                                             [  8%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_proto_wrong PASSED                                                                  [  9%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_proto_valid[default] PASSED                                                         [ 10%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_proto_valid[TLSv1.2+] PASSED                                                        [ 11%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_proto_valid[TLSv1.3+] PASSED                                                        [ 12%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_proto_valid[TLSv0x0303+] PASSED                                                     [ 12%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_honor_wrong PASSED                                                                  [ 13%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_honor_valid[on] PASSED                                                              [ 14%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_honor_valid[OfF] PASSED                                                             [ 15%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cipher_valid[default] PASSED                                                        [ 16%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cipher_valid[TLS13_AES_128_GCM_SHA256:TLS13_AES_256_GCM_SHA384:TLS13_CHACHA20_POLY1305_SHA256] PASSED [ 16%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cipher_valid[TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256] PASSED [ 17%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cipher_valid[TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 \\\n        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\\\n        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256] PASSED [ 18%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cipher_wrong[wrong] PASSED                                                          [ 19%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cipher_wrong[YOLO] PASSED                                                           [ 20%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cipher_wrong[TLS_NULL_WITH_NULL_NULLX] PASSED                                       [ 20%]
test/modules/tls/test_02_conf.py::TestConf::test_tls_02_conf_cipher_wrong[TLS_DHE_RSA_WITH_AES128_GCM_SHA256] PASSED                             [ 21%]
test/modules/tls/test_03_sni.py::TestSni::test_tls_03_sni_get_a PASSED                                                                           [ 22%]
test/modules/tls/test_03_sni.py::TestSni::test_tls_03_sni_get_b PASSED                                                                           [ 23%]
test/modules/tls/test_03_sni.py::TestSni::test_tls_03_sni_unknown PASSED                                                                         [ 24%]
test/modules/tls/test_03_sni.py::TestSni::test_tls_03_sni_request_other_same_config PASSED                                                       [ 25%]
test/modules/tls/test_03_sni.py::TestSni::test_tls_03_sni_request_other_other_honor PASSED                                                       [ 25%]
test/modules/tls/test_04_get.py::TestGet::test_tls_04_get[1k.txt-1024] PASSED                                                                    [ 26%]
test/modules/tls/test_04_get.py::TestGet::test_tls_04_get[10k.txt-10240] PASSED                                                                  [ 27%]
test/modules/tls/test_04_get.py::TestGet::test_tls_04_get[100k.txt-102400] PASSED                                                                [ 28%]
test/modules/tls/test_04_get.py::TestGet::test_tls_04_get[1m.txt-1024000] PASSED                                                                 [ 29%]
test/modules/tls/test_04_get.py::TestGet::test_tls_04_get[10m.txt-10240000] PASSED                                                               [ 29%]
test/modules/tls/test_04_get.py::TestGet::test_tls_04_double_get[1k.txt-1024] PASSED                                                             [ 30%]
test/modules/tls/test_05_proto.py::TestProto::test_tls_05_proto_1_2 PASSED                                                                       [ 31%]
test/modules/tls/test_05_proto.py::TestProto::test_tls_05_proto_1_3 PASSED                                                                       [ 32%]
test/modules/tls/test_05_proto.py::TestProto::test_tls_05_proto_close PASSED                                                                     [ 33%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_ecdsa PASSED                                                               [ 33%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_rsa PASSED                                                                 [ 34%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_ecdsa[TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256] PASSED  [ 35%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_ecdsa[TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384] PASSED        [ 36%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_ecdsa[TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256] PASSED        [ 37%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa[TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256] PASSED      [ 37%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384] PASSED            [ 38%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa[TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256] PASSED            [ 39%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa_alias[ECDHE-RSA-CHACHA20-POLY1305] PASSED                [ 40%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa_alias[ECDHE-RSA-AES256-GCM-SHA384] PASSED                [ 41%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa_alias[ECDHE-RSA-AES128-GCM-SHA256] PASSED                [ 41%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa_id[TLS_CIPHER_0xcca8] PASSED                             [ 42%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa_id[TLS_CIPHER_0xc030] PASSED                             [ 43%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_server_prefer_rsa_id[TLS_CIPHER_0xc02f] PASSED                             [ 44%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_pref_unknown PASSED                                                        [ 45%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_pref_unsupported PASSED                                                    [ 45%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_supp_unknown PASSED                                                        [ 46%]
test/modules/tls/test_06_ciphers.py::TestCiphers::test_tls_06_ciphers_supp_unsupported PASSED                                                    [ 47%]
test/modules/tls/test_07_alpn.py::TestAlpn::test_tls_07_alpn_get_a PASSED                                                                        [ 48%]
test/modules/tls/test_07_alpn.py::TestAlpn::test_tls_07_alpn_get_b PASSED                                                                        [ 49%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_root PASSED                                                                         [ 50%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_const[SERVER_NAME-b.mod-tls.test] PASSED                                            [ 50%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_const[SSL_SESSION_RESUMED-Initial] PASSED                                           [ 51%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_const[SSL_SECURE_RENEG-false] PASSED                                                [ 52%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_const[SSL_COMPRESS_METHOD-NULL] PASSED                                              [ 53%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_const[SSL_CIPHER_EXPORT-false] PASSED                                               [ 54%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_const[SSL_CLIENT_VERIFY-NONE] PASSED                                                [ 54%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_match[SSL_VERSION_INTERFACE-mod_tls/\\d+\\.\\d+\\.\\d+] PASSED                      [ 55%]
test/modules/tls/test_08_vars.py::TestVars::test_tls_08_vars_match[SSL_VERSION_LIBRARY-rustls-ffi/\\d+\\.\\d+\\.\\d+/rustls/\\d+\\.\\d+(\\.\\d+)?] PASSED [ 56%]
test/modules/tls/test_09_timeout.py::TestTimeout::test_tls_09_timeout_handshake PASSED                                                           [ 57%]
test/modules/tls/test_10_session_id.py::TestSessionID::test_tls_10_session_id_12 PASSED                                                          [ 58%]
test/modules/tls/test_10_session_id.py::TestSessionID::test_tls_10_session_id_13 SKIPPED (client side TLSv1.3 support shaky on some platforms)   [ 58%]
test/modules/tls/test_11_md.py::TestMD::test_tls_11_get_a PASSED                                                                                 [ 59%]
test/modules/tls/test_11_md.py::TestMD::test_tls_11_get_b PASSED                                                                                 [ 60%]
test/modules/tls/test_11_md.py::TestMD::test_tls_11_get_base PASSED                                                                              [ 61%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_set_ca_non_existing SKIPPED (client certs disabled)                                      [ 62%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_set_ca_existing SKIPPED (client certs disabled)                                          [ 62%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_set_auth_no_ca SKIPPED (client certs disabled)                                           [ 63%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_auth_option_std SKIPPED (client certs disabled)                                          [ 64%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_auth_option_cert SKIPPED (client certs disabled)                                         [ 65%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_auth_ssl_optional SKIPPED (client certs disabled)                                        [ 66%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_auth_optional SKIPPED (client certs disabled)                                            [ 66%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_auth_expired SKIPPED (client certs disabled)                                             [ 67%]
test/modules/tls/test_12_cauth.py::TestTLS::test_tls_12_auth_other_ca SKIPPED (client certs disabled)                                            [ 68%]
test/modules/tls/test_13_proxy.py::TestProxy::test_tls_13_proxy_http_get PASSED                                                                  [ 69%]
test/modules/tls/test_13_proxy.py::TestProxy::test_tls_13_proxy_http_vars[SERVER_NAME-b.mod-tls.test] PASSED                                     [ 70%]
test/modules/tls/test_13_proxy.py::TestProxy::test_tls_13_proxy_http_vars[SSL_SESSION_RESUMED-] PASSED                                           [ 70%]
test/modules/tls/test_13_proxy.py::TestProxy::test_tls_13_proxy_http_vars[SSL_SECURE_RENEG-] PASSED                                              [ 71%]
test/modules/tls/test_13_proxy.py::TestProxy::test_tls_13_proxy_http_vars[SSL_COMPRESS_METHOD-] PASSED                                           [ 72%]
test/modules/tls/test_13_proxy.py::TestProxy::test_tls_13_proxy_http_vars[SSL_CIPHER_EXPORT-] PASSED                                             [ 73%]
test/modules/tls/test_13_proxy.py::TestProxy::test_tls_13_proxy_http_vars[SSL_CLIENT_VERIFY-] PASSED                                             [ 74%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_get PASSED                                                            [ 75%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_get_local PASSED                                                      [ 75%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_h2_get PASSED                                                         [ 76%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_vars_const[SERVER_NAME-b.mod-tls.test] PASSED                         [ 77%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_vars_const[SSL_SESSION_RESUMED-Initial] PASSED                        [ 78%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_vars_const[SSL_SECURE_RENEG-false] PASSED                             [ 79%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_vars_const[SSL_COMPRESS_METHOD-NULL] PASSED                           [ 79%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_vars_const[SSL_CIPHER_EXPORT-false] PASSED                            [ 80%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_vars_const[SSL_CLIENT_VERIFY-NONE] PASSED                             [ 81%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_vars_match[SSL_VERSION_INTERFACE-mod_tls/\\d+\\.\\d+\\.\\d+] PASSED   [ 82%]
test/modules/tls/test_14_proxy_ssl.py::TestProxySSL::test_tls_14_proxy_ssl_vars_match[SSL_VERSION_LIBRARY-rustls-ffi/\\d+\\.\\d+\\.\\d+/rustls/\\d+\\.\\d+(\\.\\d+)?] PASSED [ 83%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_get PASSED                                                            [ 83%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_get_local PASSED                                                      [ 84%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h2_get PASSED                                                         [ 85%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h1_vars[SERVER_NAME-b.mod-tls.test] PASSED                            [ 86%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h1_vars[SSL_PROTOCOL-TLSv1.3] PASSED                                  [ 87%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h1_vars[SSL_CIPHER-TLS_AES_256_GCM_SHA384] PASSED                     [ 87%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h1_vars[SSL_SESSION_RESUMED-Initial] PASSED                           [ 88%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h1_vars[SSL_SECURE_RENEG-false] PASSED                                [ 89%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h1_vars[SSL_COMPRESS_METHOD-NULL] PASSED                              [ 90%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h1_vars[SSL_CIPHER_EXPORT-false] PASSED                               [ 91%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h1_vars[SSL_CLIENT_VERIFY-NONE] PASSED                                [ 91%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h2_vars[SERVER_NAME-b.mod-tls.test] PASSED                            [ 92%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h2_vars[SSL_PROTOCOL-TLSv1.3] PASSED                                  [ 93%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h2_vars[SSL_CIPHER-TLS_CHACHA20_POLY1305_SHA256] PASSED               [ 94%]
test/modules/tls/test_15_proxy_tls.py::TestProxyTLS::test_tls_15_proxy_tls_h2_vars[SSL_SESSION_RESUMED-Initial] PASSED                           [ 95%]
test/modules/tls/test_16_proxy_mixed.py::TestProxyMixed::test_tls_16_proxy_mixed_ssl_get[0] PASSED                                               [ 95%]
test/modules/tls/test_16_proxy_mixed.py::TestProxyMixed::test_tls_16_proxy_mixed_tls_get[0] PASSED                                               [ 96%]
test/modules/tls/test_17_proxy_machine_cert.py::TestProxyMachineCert::test_tls_17_proxy_machine_cert_get_a PASSED                                [ 97%]
test/modules/tls/test_17_proxy_machine_cert.py::TestProxyMachineCert::test_tls_17_proxy_machine_cert_vars[SERVER_NAME-a.mod-tls.test] PASSED     [ 98%]
test/modules/tls/test_17_proxy_machine_cert.py::TestProxyMachineCert::test_tls_17_proxy_machine_cert_vars[SSL_CLIENT_VERIFY-SUCCESS] PASSED      [ 99%]
test/modules/tls/test_17_proxy_machine_cert.py::TestProxyMachineCert::test_tls_17_proxy_machine_cert_vars[REMOTE_USER-user1] PASSED              [100%]

=================================================================== warnings summary ===================================================================
test/conftest.py:10
  /root/mod_tls/test/conftest.py:10: PytestRemovedIn9Warning: The (startdir: py.path.local) argument is deprecated, please use (start_path: pathlib.Path)
  see https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path
    def pytest_report_header(config, startdir):

test/modules/tls/test_01_apache.py::TestApache::test_tls_01_apache_http
  /root/mod_tls/test/pyhttpd/certs.py:40: CryptographyDeprecationWarning: Curve argument must be an instance of an EllipticCurve class. Did you pass a class by mistake? This will be an exception in a future version of cryptography
    return ec.generate_private_key(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================== 114 passed, 10 skipped, 2 warnings in 57.25s =====================================================
```
</details>


Resolves https://github.com/icing/mod_tls/issues/6