### PR TITLE
tls backend, fix flush

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,7 +42,7 @@ jobs:
   linux:
     name: ${{ matrix.build.name }} (rustls-ffi ${{matrix.rustls-version}} ${{ matrix.crypto }} ${{matrix.rust}})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/src/tls_core.c
+++ b/src/tls_core.c
@@ -1305,7 +1305,7 @@ apr_status_t tls_core_conn_post_handshake(conn_rec *c)
     cc->tls_cipher_id = rustls_connection_get_negotiated_ciphersuite(cc->rustls_connection);
     cc->tls_cipher_name = tls_proto_get_cipher_name(sc->global->proto,
         cc->tls_cipher_id, c->pool);
-    ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, c, "post_handshake %s: %s [%s]",
+    ap_log_cerror(APLOG_MARK, APLOG_TRACE1, 0, c, "[OUT] TLS handshake %s: %s [%s]",
         cc->server->server_hostname, cc->tls_protocol_name, cc->tls_cipher_name);
 
     cert = rustls_connection_get_peer_certificate(cc->rustls_connection, 0);

--- a/src/tls_filter.h
+++ b/src/tls_filter.h
@@ -28,7 +28,6 @@ struct tls_filter_ctx_t {
     apr_bucket_brigade *fin_tls_bb;      /* TLS encrypted, incoming network data */
     apr_bucket_brigade *fin_tls_buffer_bb; /* TLS encrypted, incoming network data buffering */
     apr_bucket_brigade *fin_plain_bb;    /* decrypted, incoming traffic data */
-    apr_off_t fin_bytes_in_rustls;       /* # of input TLS bytes in rustls_connection */
     apr_read_type_e fin_block;           /* Do we block on input reads or not? */
 
     ap_filter_t *fout_ctx;               /* Apache's entry into the output filter chain */
@@ -43,6 +42,8 @@ struct tls_filter_ctx_t {
     apr_size_t fout_max_in_rustls;        /* how much plain bytes we like in rustls */
     apr_size_t fout_max_bucket_size;      /* how large bucket chunks we handle before splitting */
     apr_size_t fout_auto_flush_size;      /* on much outoing TLS data we flush to network */
+    int fin_data_pending;                 /* rustls as unencrypted TSL data in input */
+    int fin_eof;                          /* encountered EOF on receiving data */
 };
 
 /**

--- a/test/modules/tls/test_18_ws.py
+++ b/test/modules/tls/test_18_ws.py
@@ -150,6 +150,8 @@ class TestWebSockets:
                 msg += ws.recv()
             except websockets.exceptions.ConnectionClosedOK:
                 return msg
+            except websockets.exceptions.ConnectionClosedError:
+                return msg
 
     def ws_recv_bytes(self, ws):
         msg = b''
@@ -157,6 +159,8 @@ class TestWebSockets:
             try:
                 msg += ws.recv()
             except websockets.exceptions.ConnectionClosedOK:
+                return msg
+            except websockets.exceptions.ConnectionClosedError:
                 return msg
 
     # verify the our plain websocket server works
@@ -187,7 +191,7 @@ class TestWebSockets:
 
     # verify to send secure websocket message pingpong through apache
     def test_tls_18_04_http_wss(self, env, wss_server):
-        pytest.skip(reason='This fails, needing a fix like PR #9')
+        # pytest.skip(reason='This fails, needing a fix like PR #9')
         with connect(f"ws://localhost:{env.http_port}/wss/echo/") as ws:
             message = "Hello world!"
             ws.send(message)

--- a/test/modules/tls/ws_server.py
+++ b/test/modules/tls/ws_server.py
@@ -9,6 +9,7 @@ import time
 
 import websockets.server as ws_server
 from websockets.exceptions import ConnectionClosedError
+from websockets.exceptions import ConnectionClosedOK
 
 log = logging.getLogger(__name__)
 
@@ -38,8 +39,11 @@ async def on_async_conn(conn):
     log.info(f'connection for {pcomps}')
     if pcomps[0] == 'echo':
         log.info(f'/echo endpoint')
-        for message in await conn.recv():
-            await conn.send(message)
+        try:
+            for message in await conn.recv():
+                await conn.send(message)
+        except ConnectionClosedOK:
+            pass
     elif pcomps[0] == 'text':
         await conn.send('hello!')
     elif pcomps[0] == 'file':


### PR DESCRIPTION
A flush of data was missing in the outgoing filter for backend conenctions that did not end in a meta bucket. This caused stalls of websocket frames from the client to never reach the backend.

Rework filter logging to give a better picture of what is happening.

refs #9